### PR TITLE
Add more linux targets and add a category

### DIFF
--- a/package.json
+++ b/package.json
@@ -100,8 +100,11 @@
     },
     "linux": {
       "target": [
-        "AppImage"
-      ]
+        "AppImage",
+        "pacman",
+        "deb"
+      ],
+      "category": "Network"
     },
     "extraMetadata": {
       "main": "build/electron.js"


### PR DESCRIPTION
Currently if you try to pack an application with linux target it will say that category is not set. I've set it to `Network` (according to [this](https://specifications.freedesktop.org/menu-spec/latest/apa.html#main-category-registry))

Also I've added special builds for Ubuntu / Debian and Arch Linux